### PR TITLE
MAESTRO: Fix browser persistence claim in README (DOC-001)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ npm install
 npm run tauri dev
 ```
 
-**Browser only (no local persistence):**
+**Browser only (drawings saved to localStorage):**
 
 ```bash
 npm run dev


### PR DESCRIPTION
Corrected misleading "(no local persistence)" to "(drawings saved to localStorage)" since the app uses localStorage fallback in browser mode.