### PR TITLE
fix(linux): AppImage EGL fix + bump to v0.0.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,41 @@ jobs:
           releaseDraft: ${{ github.event.inputs.draft || true }}
           prerelease: false
 
+      - name: Fix AppImage EGL compatibility
+        run: |
+          # The AppImage bundles Ubuntu's EGL/Mesa libs which crash on non-Ubuntu
+          # distros (Arch/Manjaro/Fedora) with "EGL_BAD_PARAMETER". Remove them
+          # so the host system's graphics drivers are used instead.
+          APPIMAGE=$(find src-tauri/target/release/bundle/appimage -name '*.AppImage' 2>/dev/null | head -1)
+          if [ -n "$APPIMAGE" ]; then
+            chmod +x "$APPIMAGE"
+            "$APPIMAGE" --appimage-extract
+
+            # Remove bundled EGL/Mesa/graphics libs that conflict with host drivers
+            rm -f squashfs-root/usr/lib/libEGL*.so*
+            rm -f squashfs-root/usr/lib/libGLESv2*.so*
+            rm -f squashfs-root/usr/lib/libgbm*.so*
+            rm -f squashfs-root/usr/lib/libdrm*.so*
+            rm -f squashfs-root/usr/lib/libglapi*.so*
+            rm -f squashfs-root/usr/lib/dri/*.so*
+
+            # Repack the AppImage
+            wget -q https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage -O appimagetool
+            chmod +x appimagetool
+            ARCH=x86_64 ./appimagetool squashfs-root "$APPIMAGE"
+
+            rm -rf squashfs-root appimagetool
+          fi
+
+      - name: Upload fixed AppImage to release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          APPIMAGE=$(find src-tauri/target/release/bundle/appimage -name '*.AppImage' 2>/dev/null | head -1)
+          if [ -n "$APPIMAGE" ]; then
+            gh release upload "v$(jq -r .version package.json)" "$APPIMAGE" --clobber
+          fi
+
       - name: Build server binary
         run: cd server && cargo build --release
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "drawfinity",
   "private": true,
-  "version": "0.0.1",
+  "version": "0.0.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drawfinity-server"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 
 [dependencies]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drawfinity"
-version = "0.0.1"
+version = "0.0.2"
 description = "An open-source infinite canvas drawing app"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,5 +2,12 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
+    // Work around WebKitGTK DMA-BUF renderer issues on non-Ubuntu Linux distros
+    // (e.g. Arch/Manjaro with Intel iGPU). Must be set before WebKitGTK initializes.
+    #[cfg(target_os = "linux")]
+    {
+        std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+    }
+
     drawfinity_lib::run()
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Drawfinity",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "identifier": "com.drawfinity.canvas",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- Bump version 0.0.1 → 0.0.2 across all config files
- Set `WEBKIT_DISABLE_DMABUF_RENDERER=1` in Rust before WebKitGTK init (Linux only)
- Post-build step strips bundled EGL/Mesa/DRI libs from AppImage and repacks it

## Context
v0.0.1 AppImage crashes on non-Ubuntu Linux (Arch/Manjaro with Intel iGPU):
```
Could not create default EGL display: EGL_BAD_PARAMETER. Aborting...
```
Caused by Ubuntu's bundled `libEGL.so` being incompatible with the host system's graphics drivers. The fix removes these libs from the AppImage so the host system's working graphics stack is used instead.

## Test plan
- [ ] CI passes (type check, tests, compile checks)
- [ ] After merge + tag v0.0.2, release builds complete
- [ ] Download Linux AppImage and verify it launches without EGL error on Manjaro
- [ ] Windows/macOS builds unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)