### PR TITLE
Add GitHub Pages deployment for docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,53 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'package.json'
+      - 'package-lock.json'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build docs
+        run: npm run docs:build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/.vitepress/dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -4,7 +4,7 @@ import { withMermaid } from 'vitepress-plugin-mermaid'
 export default withMermaid(defineConfig({
   title: 'Drawfinity',
   description: 'Infinite canvas drawing app with real-time collaboration and turtle graphics',
-  base: '/',
+  base: '/drawfinity/',
 
   head: [
     ['link', { rel: 'icon', type: 'image/png', href: '/favicon.png' }],


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow to auto-deploy VitePress docs to GitHub Pages on push to main
- Set VitePress base path to `/drawfinity/` for GitHub Pages subdirectory hosting

## Details

**New file:** `.github/workflows/docs.yml`
- Triggers on push to main when `docs/**`, `package.json`, or `package-lock.json` change
- Also supports manual `workflow_dispatch`
- Two-job pipeline: build (Node 20, npm ci, vitepress build) → deploy (actions/deploy-pages)
- Concurrency group prevents overlapping deploys

**Changed:** `docs/.vitepress/config.ts`
- `base` changed from `/` to `/drawfinity/` for `needmorecowbell.github.io/drawfinity`

## Setup required

After merging, enable GitHub Pages in repo settings:
1. Go to **Settings > Pages**
2. Set Source to **GitHub Actions**
3. Save

Docs will then be live at `https://needmorecowbell.github.io/drawfinity/`

## Test plan

- [ ] Workflow file is valid YAML
- [ ] `npm run docs:build` passes with new base path
- [ ] After merge + Pages enabled: site loads at `needmorecowbell.github.io/drawfinity`

🤖 Generated with [Claude Code](https://claude.com/claude-code)