### PR TITLE
Add docs and Made with Maestro badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@
 <p align="center"><em>An infinite canvas for drawing, collaboration, and creative coding.</em></p>
 
 <p align="center">
+  <a href="https://needmorecowbell.github.io/drawfinity/"><img src="https://img.shields.io/badge/docs-drawfinity-blue?style=flat-square" alt="Documentation"></a>
+  <a href="https://maestro.sh"><img src="https://raw.githubusercontent.com/RunMaestro/Maestro/main/docs/assets/made-with-maestro.svg" alt="Made with Maestro"></a>
+</p>
+
+<p align="center">
   <a href="https://needmorecowbell.github.io/drawfinity/">Documentation</a> &middot;
   <a href="https://github.com/needmorecowbell/drawfinity/releases">Downloads</a> &middot;
   <a href="https://needmorecowbell.github.io/drawfinity/getting-started">Getting Started</a>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   <a href="https://needmorecowbell.github.io/drawfinity/"><img src="https://img.shields.io/badge/docs-drawfinity-blue?style=flat-square" alt="Documentation"></a>
-  <a href="https://maestro.sh"><img src="https://raw.githubusercontent.com/RunMaestro/Maestro/main/docs/assets/made-with-maestro.svg" alt="Made with Maestro"></a>
+  <a href="https://runmaestro.ai"><img src="https://raw.githubusercontent.com/RunMaestro/Maestro/main/docs/assets/made-with-maestro.svg" alt="Made with Maestro"></a>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 <p align="center"><em>An infinite canvas for drawing, collaboration, and creative coding.</em></p>
 
 <p align="center">
-  <a href="https://needmorecowbell.github.io/drawfinity/"><img src="https://img.shields.io/badge/docs-drawfinity-blue?style=flat-square" alt="Documentation"></a>
   <a href="https://runmaestro.ai"><img src="https://raw.githubusercontent.com/RunMaestro/Maestro/main/docs/assets/made-with-maestro.svg" alt="Made with Maestro"></a>
 </p>
 


### PR DESCRIPTION
## Summary
- Adds a documentation badge linking to the Drawfinity docs site
- Adds a "Made with Maestro" badge linking to maestro.sh
- Badges are placed in a centered row below the tagline

## Test plan
- [ ] Verify badges render correctly in GitHub README preview
- [ ] Confirm badge links point to correct URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)